### PR TITLE
Add pages publishing CI

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,4 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.REPO_ACCESS_TOKEN }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["docs-test"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          swift package \
+            --allow-writing-to-directory docs \
+            generate-documentation \
+            --target Telemetry \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path Telemetry-iOS \
+            --output-path docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload docs folder
+          path: 'docs'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
### What:
Auto build and publish docs when pushing to a branch

### Why:
Keep published docs up to date

### How:
Used the suggested setup from GH

### Testing Notes
As usual, testing means pushing to the branch to see what happens.
