### PR TITLE
Automaticlly adding `File` facets to `record()` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Updated
 
+- Updated `record(metron:)` function to automatically append a File facet from where the function was called.
+
 ### Fixed
 
 ## 1.0.0

--- a/Sources/Telemetry/Facet/File.swift
+++ b/Sources/Telemetry/Facet/File.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-/// Facet representing the source file and line the event originated in.
+/// Facet representing the source file and line the event originated from.
 public struct File: Facet, Equatable {
 
     /// File name.

--- a/Sources/Telemetry/Telemeter/Telemeter.swift
+++ b/Sources/Telemetry/Telemeter/Telemeter.swift
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 import Foundation
-import os
 
 /// A type that can record ``Metron``s.
 public protocol Telemeter {
@@ -36,11 +35,17 @@ public protocol Telemeter {
 // MARK: - Record Convenience
 
 extension Telemeter {
-    /// Records a ``Metron`` to the receiving ``Telemeter``.
+    /// Records a ``Metron`` to the receiving ``Telemeter`` and attaches a ``File`` facet.
     ///
     /// - Parameter metron: The `Metron` to record.
-    public func record(_ metron: Metron) {
-        record(metron, adding: [])
+    /// - Note: Automatically appends a ``File`` facet with the `fileID` and `line` the function was called from.
+    public func record(_ metron: Metron, file: StaticString = #fileID, line: UInt = #line) {
+        record(
+            metron,
+            adding: [
+                File(name: file, line: line)
+            ]
+        )
     }
 }
 
@@ -69,11 +74,10 @@ extension Telemeter {
         message: String,
         error: Error? = nil,
         significance: Significance = .debug,
-        file: StaticString = #fileID,
-        line: UInt = #line)
+        file: StaticString,
+        line: UInt)
     {
         var facets: [Facet] = [
-            File(name: file, line: line),
             significance
         ]
 
@@ -83,7 +87,7 @@ extension Telemeter {
 
         let metron = LogMetron(message: message, facets: facets)
 
-        record(metron)
+        record(metron, file: file, line: line)
     }
 }
 

--- a/Sources/Telemetry/Telemeter/Telemeter.swift
+++ b/Sources/Telemetry/Telemeter/Telemeter.swift
@@ -27,7 +27,8 @@ public protocol Telemeter {
 
     /// Records a ``Metron`` along with the provided ``Facet``s to the receiving ``Telemeter``.
     ///
-    /// This function is intended only for internal Telemetry use. Users should prefer ``record(_:file:line:)`` when recording Metrons so that the File facet is appened.
+    /// This function is intended only for internal Telemetry use. Users should prefer ``record(_:file:line:)``
+    /// when recording Metrons so that the File facet is appened.
     ///
     /// - Parameters:
     ///   - metron: The `Metron` to record.

--- a/Sources/Telemetry/Telemeter/Telemeter.swift
+++ b/Sources/Telemetry/Telemeter/Telemeter.swift
@@ -24,7 +24,10 @@ import Foundation
 
 /// A type that can record ``Metron``s.
 public protocol Telemeter {
+
     /// Records a ``Metron`` along with the provided ``Facet``s to the receiving ``Telemeter``.
+    ///
+    /// This function is intended only for internal Telemetry use. Users should prefer ``record(_:file:line:)`` when recording Metrons so that the File facet is appened.
     ///
     /// - Parameters:
     ///   - metron: The `Metron` to record.

--- a/Tests/TelemetryTests/Telemeter/TelemeterTests.swift
+++ b/Tests/TelemetryTests/Telemeter/TelemeterTests.swift
@@ -96,6 +96,24 @@ class TelemeterTests: XCTestCase {
             }
         }
     }
+
+    func testRecordAddsFileFacet() {
+        // Given
+        let expectedFileName = "TelemeterTests.swift"
+        let expectedLineNumber: UInt = #line + 3
+
+        // When
+        telemeter.record(SomeMetron())
+
+        // Then
+        XCTAssertEqual(telemeter.metroids.count, 1) {
+            let metroid = telemeter.metroids[0]
+            XCTAssertNotNil(metroid.facets.first(ofType: File.self)) { file in
+                XCTAssert(file.name, contains: expectedFileName)
+                XCTAssertEqual(file.line, expectedLineNumber)
+            }
+        }
+    }
 }
 
 private class MockRelay: Relay {


### PR DESCRIPTION
### What:

Updated `record(metron:)` function to automatically append a File facet from where the function was called

### Why:

Provides more context to the relays which can improve analytics and debugging.

### How:

Added `file: StaticString` and `line: UInt` parameters to `record(metron:)` and set default values of `#fileID` and `#line`, respectivly. Used those values to create a `File` facet and included that in the array passed to `record(metron:adding:)`

### Testing Notes

Updated tests to validate the line was captured. 

